### PR TITLE
Add handling for class "Item" property "text" being null

### DIFF
--- a/export-kobo.py
+++ b/export-kobo.py
@@ -126,7 +126,10 @@ class Item(object):
 
     def __init__(self, values):
         self.volumeid = values[0]
-        self.text = values[1].strip().rstrip()
+        if values[1] is not None:
+            self.text = values[1].strip().rstrip()
+        else:
+            self.text = None
         self.annotation = values[2]
         self.extraannotationdata = values[3]
         self.datecreated = values[4] if values[4] is not None else "1970-01-01T00:00:00.000"

--- a/export-kobo.py
+++ b/export-kobo.py
@@ -126,10 +126,7 @@ class Item(object):
 
     def __init__(self, values):
         self.volumeid = values[0]
-        if values[1] is not None:
-            self.text = values[1].strip().rstrip()
-        else:
-            self.text = None
+        self.text = values[1].strip().rstrip() if values[1] is not None else None
         self.annotation = values[2]
         self.extraannotationdata = values[3]
         self.datecreated = values[4] if values[4] is not None else "1970-01-01T00:00:00.000"


### PR DESCRIPTION
## Disclaimer
First pull request. Roast me.

Fixes #1 

## Problem

In the Item class, the __init__ method was encountering an error on assigning self.text with values[1] when it was null, as it was calling strip on a null value

## Why does the problem exist

I do not know what changed (if anything) in the sqlite schema to cause this new issue.

## Solution
Adding a quick check to only set the property if the value is not none fixes the immediate issues, however the self.text property must exist for line 141, so I added an else clause to manually set to None.

