### PR TITLE
Add chapter headings to export and make flask import modular

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # Kobo db
 KoboReader.sqlite
+
+# vim
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A Python tool to export annotations and highlights from a Kobo SQLite file. Now 
 
 Works with Python 3 only.
 
-**Tested with latest Kobo Clara**
+**Tested with the latest Kobo Clara**
 
 ## Usage
 
@@ -28,6 +28,9 @@ $ python3 export-kobo.py KoboReader.sqlite --kindle
 
 $ # export in Markdown list format
 $ python3 export-kobo.py KoboReader.sqlite --markdown
+
+$ # export in Markdown list format and add chapter headings 
+$ python3 export-kobo.py KoboReader.sqlite --markdown --add-chapter-headings
 
 $ # export annotations only
 $ python3 export-kobo.py KoboReader.sqlite --annotations-only
@@ -213,7 +216,7 @@ Alberto Pettarin for the [original version](https://github.com/pettarin/export-k
 * Curiositry suggested adding an option to extract in Kindle My Clippings format.
 * Frederic Da Vitoria confirmed that the export script works for the Kobo app for Desktop PC.
 * Matthieu Nantern contributed the ``raw`` export mode.
-
+* Burkhard Ringlein contributed the `--add-chapter-headings` mode.
 
 ## License
 
@@ -222,4 +225,4 @@ Alberto Pettarin for the [original version](https://github.com/pettarin/export-k
 
 ---
 
-Elia Scotto | [Website](https://www.scotto.me)
+originally by Elia Scotto | [Website](https://www.scotto.me)

--- a/export-kobo.py
+++ b/export-kobo.py
@@ -5,7 +5,6 @@ import io
 import os
 import sqlite3
 import sys
-from flask import Flask, g, render_template
 
 
 DAYS = [
@@ -33,32 +32,7 @@ MONTHS = [
     "December",
 ]
 
-app = Flask(__name__)
 book_manager = None
-
-@app.before_request
-def before_request():
-    g.book_manager = book_manager
-
-@app.route('/')
-def index():
-    """
-    Index page displays only the list of books.
-    """
-    books = [x[1] for x in g.book_manager.get_books()]
-    return render_template('index.html', books=books)
-
-@app.route('/book/<int:book_id>')
-def book_details(book_id):
-    """
-    When user click on a book, show all the information displayed.
-    """
-    books = [x[1] for x in g.book_manager.get_books()]
-    (book, items) = g.book_manager.get_book_with_items_by_index(book_id)
-    if book and items:
-        return render_template('index.html', books=books, book=book, book_items=items)
-    else:
-        return "Book not found."
 
 
 class CommandLineTool(object):
@@ -518,6 +492,33 @@ class ExportKobo(CommandLineTool):
         """
         Starts the server.
         """
+        from flask import Flask, g, render_template
+        app = Flask(__name__)
+
+        @app.before_request
+        def before_request():
+            g.book_manager = book_manager
+
+        @app.route('/')
+        def index():
+            """
+            Index page displays only the list of books.
+            """
+            books = [x[1] for x in g.book_manager.get_books()]
+            return render_template('index.html', books=books)
+
+        @app.route('/book/<int:book_id>')
+        def book_details(book_id):
+            """
+            When user click on a book, show all the information displayed.
+            """
+            books = [x[1] for x in g.book_manager.get_books()]
+            (book, items) = g.book_manager.get_book_with_items_by_index(book_id)
+            if book and items:
+                return render_template('index.html', books=books, book=book, book_items=items)
+            else:
+                return "Book not found."
+
         app.run()
 
     def list_to_markdown(self, books):


### PR DESCRIPTION
This PR has two contributions
1. It makes the import of the `flask` package only in case the webapp is started, so that it is not a mandatory dependency in all cases. 
2. Added a new feature `--add-chapter-headings`: This feature adds the chapter headings of annotations and highlights to the exported text (without duplicates). 