### PR TITLE
Populate self.items before running UI so they're ready for the UI

### DIFF
--- a/export-kobo.py
+++ b/export-kobo.py
@@ -433,6 +433,7 @@ class ExportKobo(CommandLineTool):
         dict_books, enum_books = self.read_books()
 
         if self.vargs["ui"]:
+            self.read_items(dict_books, enum_books)
             self.run_server()
         else:
             if self.vargs["list"]:


### PR DESCRIPTION
This changes fixes the issue of the items list being empty and the UI therefore not being able to show the items for a book