### PR TITLE
Update the markdown front matter to use title: and author:

### DIFF
--- a/export-kobo.py
+++ b/export-kobo.py
@@ -253,7 +253,7 @@ class Book(object):
         return self.__repr__()
 
     def to_markdown(self):
-        return "# {}\n## by {}\n---\n\n".format(self.title, self.author)
+        return "---\ntitle: {}\nauthor: {}\n---\n\n".format(self.title, self.author)
 
 
 class ExportKobo(CommandLineTool):


### PR DESCRIPTION
This change updates the front matter to use the common front matter items `title:` and `author:`

https://www.markdowntoolbox.com/blog/common-front-matter/