### PR TITLE
Add shebang to allow script to be run without python3 prefix

### DIFF
--- a/export-kobo.py
+++ b/export-kobo.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import argparse
 import datetime
 import csv


### PR DESCRIPTION
This will allow the script to be run without specifying "python3" at the beginning on *nix systems, and will be ignored by Windows.